### PR TITLE
Encoding and sending frames back!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+cov.out
 certs/
 build/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+
+GOFILES := $(wildcard **/*.go)
+
+.PHONY: test
+test: cov.out
+
+cov.out: $(GOFILES)
+	go test -coverprofile=cov.out ./...
+
+.PHONY: htmlcov
+htmlcov: cov.out
+	go tool cover -html cov.out

--- a/frame/frame.go
+++ b/frame/frame.go
@@ -1,6 +1,7 @@
 package frame
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -42,6 +43,20 @@ func (fh *FrameHeader) Unmarshal(rd io.Reader) error {
 	fh.Sid = Sid(binary.BigEndian.Uint32(buf[5:]))
 
 	return nil
+}
+
+func (fh *FrameHeader) Marshal(wr io.Writer) error {
+	var buf [9]uint8
+
+	buf[0] = uint8(fh.Length >> 16)
+	buf[1] = uint8(fh.Length >> 8)
+	buf[2] = uint8(fh.Length)
+	buf[3] = uint8(fh.Type)
+	buf[4] = uint8(fh.Flags)
+	binary.BigEndian.PutUint32(buf[5:], uint32(fh.Sid))
+
+	_, err := io.Copy(wr, bytes.NewReader(buf[:]))
+	return err
 }
 
 func (fh *FrameHeader) String() string {

--- a/frame/frame_test.go
+++ b/frame/frame_test.go
@@ -2,6 +2,7 @@ package frame
 
 import (
 	"bytes"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,4 +36,23 @@ func TestFrameHeaderUnmarshal(t *testing.T) {
 	assert.Equal(t, typ, fh.Type)
 	assert.Equal(t, flags, fh.Flags)
 	assert.Equal(t, Sid(420), fh.Sid)
+}
+
+func TestFrameHeaderMarshal(t *testing.T) {
+	fh := new(FrameHeader)
+
+	fh.Sid = 0xfabb1208
+	fh.Type = FrameHeaders
+	fh.Flags = 0b101
+	fh.Length = 255
+
+	var buf bytes.Buffer
+
+	assert.NoError(t, fh.Marshal(&buf))
+	data, _ := io.ReadAll(&buf)
+
+	exp := []byte{0x00, 0x00, 0xff, uint8(FrameHeaders), 0b101, 0xfa, 0xbb, 0x12, 0x08}
+	for i := 0; i < 9; i++ {
+		assert.Equal(t, exp[i], data[i])
+	}
 }

--- a/handle.go
+++ b/handle.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"fmt"
 	"bufio"
 	"errors"
+	"fmt"
 	"http2/frame"
 	"http2/session"
 	"io"
@@ -42,7 +42,7 @@ func HandleConnection(conn net.Conn) error {
 		return err
 	}
 	globalStream := sess.Stream(0)
-	
+
 	stgs, err := globalStream.ExpectFrameType(frame.FrameSettings)
 	if err != nil {
 		return err
@@ -50,7 +50,7 @@ func HandleConnection(conn net.Conn) error {
 	data := make([]uint8, stgs.Length)
 	if _, err := io.ReadFull(buf, data); err != nil {
 		return err
-	}	
+	}
 	sl := session.SettingsListFromFramePayload(data)
 	fmt.Println("---(INITIAL CLIENT SETTINGS)---")
 	for _, item := range sl.Settings {
@@ -70,7 +70,7 @@ func HandleConnection(conn net.Conn) error {
 		data := make([]uint8, fh.Length)
 		if _, err := io.ReadFull(buf, data); err != nil {
 			return err
-		}	
+		}
 		sess.Dispatch(fh, data)
 		outbuf.Flush()
 	}

--- a/handle_test.go
+++ b/handle_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandle_Error(t *testing.T) {
+	sameLengthWrongChars := make([]byte, len(ClientPreface))
+	copy(sameLengthWrongChars, ClientPreface)
+	sameLengthWrongChars[0] = 'I'
+	cases := [][]byte{
+		ClientPreface[:10],
+		sameLengthWrongChars,
+	}
+
+	for _, c := range cases {
+		t.Run(string(c), func(t *testing.T) {
+			err := ConsumePreface(bytes.NewReader(c))
+			assert.Equal(t, UnexpectedPreface, err)
+		})
+	}
+}

--- a/hpack/header.go
+++ b/hpack/header.go
@@ -100,8 +100,8 @@ func (lh *LiteralHeader) ShouldIndex() bool {
 func (lh *LiteralHeader) Encode() []uint8 {
 	var (
 		prefixLength int
-		msb uint8
-		data bytes.Buffer
+		msb          uint8
+		data         bytes.Buffer
 	)
 	switch lh.Type {
 	case IncrementalIndex:
@@ -194,4 +194,3 @@ func literalHeader(data []uint8, typ LiteralIndexType, prefixSize int) (Header, 
 	lh.ValueLiteral = string(s)
 	return &lh, totalRead, nil
 }
-

--- a/hpack/header_test.go
+++ b/hpack/header_test.go
@@ -1,0 +1,38 @@
+package hpack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIndexedHeaderDontIndex(t *testing.T) {
+	assert.False(t, IndexedHeader(33).ShouldIndex())
+}
+
+//	8   0   f   d
+//
+// 0000000011111101
+func TestIndexedHeaderEncode(t *testing.T) {
+
+	cases := []struct {
+		C uint32
+		E string
+	}{
+		{C: 32, E: "\xa0"},
+		{C: 16000 + 127, E: "\xff\x80\x7d"},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%#v", c.E), func(t *testing.T) {
+			data := IndexedHeader(c.C).Encode()
+			assert.Equal(t, len(c.E), len(data))
+
+			for i := 0; i < len(data); i++ {
+				assert.Equal(t, c.E[i], data[i])
+			}
+			assert.NotEqual(t, data[0]&0x80, 0)
+		})
+	}
+}

--- a/hpack/headerlist.go
+++ b/hpack/headerlist.go
@@ -1,14 +1,14 @@
 package hpack
 
 import (
-	"io"
 	"bytes"
+	"io"
 	"strings"
 )
 
 type HeaderList struct {
 	data bytes.Buffer
-	tbl *HeaderLookupTable
+	tbl  *HeaderLookupTable
 }
 
 func NewHeaderList(table *HeaderLookupTable) *HeaderList {
@@ -25,8 +25,8 @@ func (hl *HeaderList) Put(k, v string) {
 	if ind > 0 && !justKey {
 		hl.data.Write(IndexedHeader(ind).Encode())
 		return
-	} 
-	
+	}
+
 	hdr := new(LiteralHeader)
 	switch k {
 	case "authorization":

--- a/hpack/headerlist.go
+++ b/hpack/headerlist.go
@@ -1,0 +1,51 @@
+package hpack
+
+import (
+	"io"
+	"bytes"
+	"strings"
+)
+
+type HeaderList struct {
+	data bytes.Buffer
+	tbl *HeaderLookupTable
+}
+
+func NewHeaderList(table *HeaderLookupTable) *HeaderList {
+	return &HeaderList{
+		tbl: table,
+	}
+}
+
+func (hl *HeaderList) Put(k, v string) {
+	k = strings.ToLower(k)
+	v = strings.ToLower(v)
+
+	ind, justKey := hl.tbl.Find(k, v)
+	if ind > 0 && !justKey {
+		hl.data.Write(IndexedHeader(ind).Encode())
+		return
+	} 
+	
+	hdr := new(LiteralHeader)
+	switch k {
+	case "authorization":
+		hdr.Type = NeverIndex
+	case ":path":
+		hdr.Type = NoIndex
+	default:
+		hdr.Type = IncrementalIndex
+	}
+	if ind > 0 {
+		hdr.KeyIndex = uint32(ind)
+	} else {
+		hdr.KeyLiteral = k
+	}
+	hdr.ValueLiteral = v
+	hl.data.Write(hdr.Encode())
+}
+
+func (hl *HeaderList) Dump() []byte {
+	data, _ := io.ReadAll(&hl.data)
+	return data
+}

--- a/hpack/primitive.go
+++ b/hpack/primitive.go
@@ -75,15 +75,15 @@ func EncodeInteger(n uint32, prefixLength int) []byte {
 	if n < uint32(prefixMask) {
 		return []byte{uint8(n)}
 	}
-	
+
 	ret := append(make([]byte, 0, 5), prefixMask)
 	rest := n - uint32(prefixMask)
 	for rest > 0 {
-		ret = append(ret, uint8(rest) & 0x7f)
+		ret = append(ret, uint8(rest)&0x7f)
 		rest >>= 7
 	}
-	// Set the last bit to signify the end of the integer 
-	ret[len(ret) - 1] |= 0x80
+	// Set the last bit to signify the end of the integer
+	ret[len(ret)-1] |= 0x80
 	return ret
 }
 
@@ -117,8 +117,10 @@ func EncodeString(data []byte) []byte {
 	}
 
 	lenEncoded := EncodeInteger(uint32(len(payloadToEncode)), 7)
-	lenEncoded[0] |= 0x80
-	ret := make([]uint8, len(lenEncoded) + len(payloadToEncode))
+	if shouldUseHuffman {
+		lenEncoded[0] |= 0x80
+	}
+	ret := make([]uint8, len(lenEncoded)+len(payloadToEncode))
 	n := copy(ret, lenEncoded)
 	copy(ret[n:], payloadToEncode)
 

--- a/hpack/primitive.go
+++ b/hpack/primitive.go
@@ -5,27 +5,7 @@ import (
 )
 
 func oneMask(n int) uint8 {
-	switch n {
-	case 0:
-		return 0
-	case 1:
-		return 0b1
-	case 2:
-		return 0b11
-	case 3:
-		return 0b111
-	case 4:
-		return 0b1111
-	case 5:
-		return 0b11111
-	case 6:
-		return 0b111111
-	case 7:
-		return 0b1111111
-	case 8:
-		return 0b11111111
-	}
-	return 0
+	return (1 << n) - 1
 }
 
 // DecodeInteger decodes an HPACK-encoded integer. HPACK-encoded integers
@@ -72,18 +52,18 @@ func DecodeInteger(data []uint8, prefixLength int) (uint32, int, error) {
 
 func EncodeInteger(n uint32, prefixLength int) []byte {
 	prefixMask := oneMask(prefixLength)
-	if n < uint32(prefixMask) {
+	if n <= uint32(prefixMask) {
 		return []byte{uint8(n)}
 	}
 
 	ret := append(make([]byte, 0, 5), prefixMask)
 	rest := n - uint32(prefixMask)
 	for rest > 0 {
-		ret = append(ret, uint8(rest)&0x7f)
+		ret = append(ret, (uint8(rest)&0x7f)|0x80)
 		rest >>= 7
 	}
 	// Set the last bit to signify the end of the integer
-	ret[len(ret)-1] |= 0x80
+	ret[len(ret)-1] &= 0x7F
 	return ret
 }
 

--- a/hpack/primitive.go
+++ b/hpack/primitive.go
@@ -70,6 +70,23 @@ func DecodeInteger(data []uint8, prefixLength int) (uint32, int, error) {
 	return ret + uint32(prefix), i + 1, nil
 }
 
+func EncodeInteger(n uint32, prefixLength int) []byte {
+	prefixMask := oneMask(prefixLength)
+	if n < uint32(prefixMask) {
+		return []byte{uint8(n)}
+	}
+	
+	ret := append(make([]byte, 0, 5), prefixMask)
+	rest := n - uint32(prefixMask)
+	for rest > 0 {
+		ret = append(ret, uint8(rest) & 0x7f)
+		rest >>= 7
+	}
+	// Set the last bit to signify the end of the integer 
+	ret[len(ret) - 1] |= 0x80
+	return ret
+}
+
 // DecodeString decodes an hpack-encoded string.
 // Strings begin with an hpack-encoded integer of prefix 7
 // which represent the length of the string data on the wire.
@@ -88,4 +105,22 @@ func DecodeString(data []uint8) ([]byte, int, error) {
 		stringData = HpackHuffmanTree.Decode(stringData)
 	}
 	return stringData, int(dataLength) + numRead, nil
+}
+
+func EncodeString(data []byte) []byte {
+	huffEncoded := HpackHuffmanTree.Encode(data)
+	shouldUseHuffman := len(huffEncoded) < len(data)
+
+	payloadToEncode := data
+	if shouldUseHuffman {
+		payloadToEncode = huffEncoded
+	}
+
+	lenEncoded := EncodeInteger(uint32(len(payloadToEncode)), 7)
+	lenEncoded[0] |= 0x80
+	ret := make([]uint8, len(lenEncoded) + len(payloadToEncode))
+	n := copy(ret, lenEncoded)
+	copy(ret[n:], payloadToEncode)
+
+	return ret
 }

--- a/hpack/primitive_test.go
+++ b/hpack/primitive_test.go
@@ -1,0 +1,80 @@
+package hpack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeInteger(t *testing.T) {
+	cases := []struct{D string; P int; E uint32; Enr int;}{
+		{"\x47", 6, 7, 1},
+		{"\x47", 7, 71, 1},
+		{"\x07\x0e", 3, 21, 2},
+		{"\x07\x83\x01", 3, 138, 3},
+		{"\x07\x83\x01\xff", 3, 138, 3},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%#v,%d-->%d", c.D, c.P, c.E), func(t *testing.T) {
+			assert := assert.New(t)
+			n, numRead, err := DecodeInteger([]byte(c.D), c.P)
+			assert.NoError(err)
+			assert.Equal(c.E, n)
+			assert.Equal(c.Enr, numRead)
+		})
+	}
+}
+
+func TestDecodeInteger_Error(t *testing.T) {
+	_, _, err := DecodeInteger([]byte("\x07\x83"), 3)
+	assert.Error(t, err)
+}
+
+func TestEncodeInteger(t *testing.T) {
+	cases := []struct{N uint32; P int; E string}{
+		{127, 7, "\x7f"},
+		{127, 5, "\x1f\x60"},
+		{0xffffffff, 7, "\x7f\x80\xff\xff\xff\x0f"},
+		{255, 8, "\xff"},
+	}
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%d,%d", c.N, c.P), func(t *testing.T) {
+			data := EncodeInteger(c.N, c.P )
+			// mask the non-prefix bits as we don't care about them
+			data[0] &= (1 << c.P) - 1
+			assert.Equal(t, c.E, string(data)) 
+		})
+	}
+}
+
+func TestEncodeString(t *testing.T) {
+	data := "*/*"
+	encoded := EncodeString([]byte(data))
+	assert.Equal(t, "\x03*/*", string(encoded))
+}
+
+func TestEncodeStringHuffman(t *testing.T) {
+	data := "racecar"
+	encoded := EncodeString([]byte(data))
+
+	exp := "\x85\xb0\x64\x29\x07\x67"
+	assert.Equal(t, exp, string(encoded))
+}
+
+func TestDecodeStringNoHuffman(t *testing.T) {
+	cases := []struct{Name string; D string; ENumRead int; Exp string}{
+		{"NoHuffman", "\x02BRUH", 3, "BR"},
+		{"Huffman", "\x82\x8c\xbf", 3, "be"},
+	}
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%v, %d", c.D, c.ENumRead), func(t *testing.T) {
+			decoded, nRead, err := DecodeString([]byte(c.D))
+			assert.NoError(t, err)
+			assert.Equal(t, c.ENumRead, nRead)
+			assert.Equal(t, c.Exp, string(decoded))
+		})
+	}
+}
+

--- a/hpack/table.go
+++ b/hpack/table.go
@@ -24,15 +24,15 @@ type HeaderLookupTable struct {
 
 func NewHeaderLookupTable() *HeaderLookupTable {
 	return &HeaderLookupTable{
-		entries:    make([]TableEntry, 16),
-		lo:         0,
+		entries: make([]TableEntry, 16),
+		lo:      0,
 
 		// The number of entries in the table
 		numEntries: 0,
 
-		// Size in octets of this table 
-		size:       0,
-		maxSize:    1024,
+		// Size in octets of this table
+		size:    0,
+		maxSize: 1024,
 	}
 }
 
@@ -134,8 +134,8 @@ func (dt *HeaderLookupTable) String() string {
 
 func (tbl *HeaderLookupTable) Find(k, v string) (idx int, justKey bool) {
 	idx = -1
-	for i := 1; i < tbl.NumEntries() + 1; i ++ {
-		ek, ev, _ := tbl.Lookup(i) 
+	for i := 1; i < tbl.NumEntries()+1; i++ {
+		ek, ev, _ := tbl.Lookup(i)
 		if ek == k && ev == v {
 			idx = i
 			justKey = false
@@ -145,7 +145,7 @@ func (tbl *HeaderLookupTable) Find(k, v string) (idx int, justKey bool) {
 			justKey = true
 		}
 	}
-	return 
+	return
 }
 
 var StaticTable = []TableEntry{

--- a/hpack/table.go
+++ b/hpack/table.go
@@ -26,10 +26,18 @@ func NewHeaderLookupTable() *HeaderLookupTable {
 	return &HeaderLookupTable{
 		entries:    make([]TableEntry, 16),
 		lo:         0,
+
+		// The number of entries in the table
 		numEntries: 0,
+
+		// Size in octets of this table 
 		size:       0,
 		maxSize:    1024,
 	}
+}
+
+func (dt *HeaderLookupTable) NumEntries() int {
+	return len(StaticTable) + dt.numEntries
 }
 
 func (dt *HeaderLookupTable) SetMaxSize(ms int) {
@@ -122,6 +130,22 @@ func (dt *HeaderLookupTable) String() string {
 	})
 	fmt.Fprintf(&sb, "Table Size: %d\n", dt.size)
 	return sb.String()
+}
+
+func (tbl *HeaderLookupTable) Find(k, v string) (idx int, justKey bool) {
+	idx = -1
+	for i := 1; i < tbl.NumEntries() + 1; i ++ {
+		ek, ev, _ := tbl.Lookup(i) 
+		if ek == k && ev == v {
+			idx = i
+			justKey = false
+			return
+		} else if ek == k && idx == -1 {
+			idx = i
+			justKey = true
+		}
+	}
+	return 
 }
 
 var StaticTable = []TableEntry{

--- a/main.go
+++ b/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"bufio"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net"
+	"strings"
 )
 
 func Must[T any](v T, err error) T {
@@ -34,6 +37,16 @@ func serverMain() {
 	}
 }
 
+func NestedBuf(rd io.Reader) {
+	buf := bufio.NewReader(rd)
+	fmt.Printf("NestedBuf got this char: %c\n", Must(buf.ReadByte()))
+}
+
 func main() {
-	serverMain()
+	data := strings.NewReader("Hello, world")
+	NestedBuf(data)
+
+	rest := make([]byte, 1024)
+	n, err := data.Read(rest)
+	fmt.Printf("%d %e\n", n, err)
 }

--- a/session/session.go
+++ b/session/session.go
@@ -63,7 +63,7 @@ const (
 func (sess *Session) HandleHeader(fh *frame.FrameHeader, data []uint8) error {
 	totRead := 0
 	padLength := 0
-	
+
 	// End of headers
 	if !fh.Flag(2) {
 		// TODO: This server doesn't support continuation frames yet. fix it!
@@ -82,7 +82,7 @@ func (sess *Session) HandleHeader(fh *frame.FrameHeader, data []uint8) error {
 		fmt.Printf("STREAM DEPENDENCY: %d --> %d (weight %d)\n", fh.Sid, depSid, weight)
 		totRead += 5
 	}
-	for totRead < len(data) - padLength {
+	for totRead < len(data)-padLength {
 		hdr, numRead, err := hpack.NextHeader(data[totRead:])
 		if err != nil {
 			return err
@@ -104,7 +104,7 @@ func (sess *Session) HandleHeader(fh *frame.FrameHeader, data []uint8) error {
 		hl.Put(":status", "404")
 		hl.Put("what", "is the meaning of this? why are we here? just to suffer?")
 		st := sess.Stream(fh.Sid)
-		st.SendFrame(frame.FrameHeaders, FLAG_END_STREAM | FLAG_END_HEADERS, hl.Dump())
+		st.SendFrame(frame.FrameHeaders, FLAG_END_STREAM|FLAG_END_HEADERS, hl.Dump())
 		fmt.Println("sent frame")
 	}
 	fmt.Println(sess.LookupTable)

--- a/session/session.go
+++ b/session/session.go
@@ -1,7 +1,9 @@
 package session
 
 import (
+	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"http2/frame"
 	"http2/hpack"
@@ -12,15 +14,22 @@ import (
 // between this server and a client.
 type Session struct {
 	Incoming io.Reader
+	Outgoing io.Writer
 
 	LookupTable *hpack.HeaderLookupTable
 }
 
-func NewSession(rd io.Reader) *Session {
+func NewSession(rd io.Reader, wr io.Writer) *Session {
 	var sess Session
 	sess.Incoming = rd
+	sess.Outgoing = wr
+
 	sess.LookupTable = hpack.NewHeaderLookupTable()
 	return &sess
+}
+
+func (sess *Session) Stream(sid frame.Sid) *Stream {
+	return &Stream{Sid: sid, Session: sess}
 }
 
 // Dispatch a frame header and payload to the appropriate handler.
@@ -32,27 +41,72 @@ func (sess *Session) Dispatch(fh *frame.FrameHeader, data []uint8) error {
 		for _, item := range sl.Settings {
 			fmt.Printf("%s = %d\n", item.Type, item.Value)
 		}
+		sess.Stream(0).SendFrame(frame.FrameSettings, STGS_ACK, nil)
 	case frame.FrameHeaders:
-		totRead := 0
-		for totRead < len(data) {
-			hdr, numRead, err := hpack.NextHeader(data[totRead:])
-			if err != nil {
-				return err
-			}
-			totRead += numRead
-			k, v, err := hdr.Resolve(sess.LookupTable)
-			if err != nil {
-				return err
-			}
-			fmt.Printf("%s: %s\n", k, v)
-			if hdr.ShouldIndex() {
-				sess.LookupTable.Insert(k, v)
-			}
+		if err := sess.HandleHeader(fh, data); err != nil {
+			return err
 		}
-		fmt.Println(sess.LookupTable)
 	default:
 		fmt.Println(hex.Dump(data))
 	}
 	fmt.Println("------------------------------------------------------------")
+	return nil
+}
+
+const (
+	FLAG_END_STREAM  uint8 = 0x01
+	FLAG_END_HEADERS uint8 = 0x04
+	FLAG_PADDED      uint8 = 0x08
+	FLAG_PRIORITY    uint8 = 0x20
+)
+
+func (sess *Session) HandleHeader(fh *frame.FrameHeader, data []uint8) error {
+	totRead := 0
+	padLength := 0
+	
+	// End of headers
+	if !fh.Flag(2) {
+		// TODO: This server doesn't support continuation frames yet. fix it!
+		return errors.New("END_OF_HEADERS not set. This server doesn't support continuation")
+	}
+
+	// Padded
+	if fh.Flag(3) {
+		padLength = int(data[0])
+		totRead += 1
+	}
+	// Priority
+	if fh.Flag(5) {
+		depSid := binary.BigEndian.Uint32(data[totRead:])
+		weight := data[totRead+4]
+		fmt.Printf("STREAM DEPENDENCY: %d --> %d (weight %d)\n", fh.Sid, depSid, weight)
+		totRead += 5
+	}
+	for totRead < len(data) - padLength {
+		hdr, numRead, err := hpack.NextHeader(data[totRead:])
+		if err != nil {
+			return err
+		}
+		totRead += numRead
+		k, v, err := hdr.Resolve(sess.LookupTable)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%s: %s\n", k, v)
+		if hdr.ShouldIndex() {
+			sess.LookupTable.Insert(k, v)
+		}
+	}
+	// End of stream
+	if fh.Flag(0) {
+		fmt.Printf("END OF STREAM %d\n", fh.Sid)
+		hl := hpack.NewHeaderList(sess.LookupTable)
+		hl.Put(":status", "404")
+		hl.Put("what", "is the meaning of this? why are we here? just to suffer?")
+		st := sess.Stream(fh.Sid)
+		st.SendFrame(frame.FrameHeaders, FLAG_END_STREAM | FLAG_END_HEADERS, hl.Dump())
+		fmt.Println("sent frame")
+	}
+	fmt.Println(sess.LookupTable)
 	return nil
 }

--- a/session/settings.go
+++ b/session/settings.go
@@ -27,6 +27,9 @@ const (
 	SettingsMaxHeaderListSize
 )
 
+// STGS_ACK is a flag used in a settings 
+const STGS_ACK = 0x01
+
 type setting struct {
 	Type  SettingsType
 	Value uint32

--- a/session/settings.go
+++ b/session/settings.go
@@ -27,7 +27,7 @@ const (
 	SettingsMaxHeaderListSize
 )
 
-// STGS_ACK is a flag used in a settings 
+// STGS_ACK is a flag used in a settings
 const STGS_ACK = 0x01
 
 type setting struct {

--- a/session/stream.go
+++ b/session/stream.go
@@ -1,8 +1,8 @@
 package session
 
 import (
-	"fmt"
 	"bytes"
+	"fmt"
 	"http2/frame"
 	"io"
 )
@@ -10,7 +10,7 @@ import (
 // A stream represents a single two-way channel
 // within a session.
 type Stream struct {
-	Sid frame.Sid
+	Sid     frame.Sid
 	Session *Session
 }
 
@@ -45,4 +45,3 @@ func (stream *Stream) ExpectFrameType(typ frame.FrameType) (*frame.FrameHeader, 
 	}
 	return fh, nil
 }
-

--- a/session/stream.go
+++ b/session/stream.go
@@ -1,0 +1,48 @@
+package session
+
+import (
+	"fmt"
+	"bytes"
+	"http2/frame"
+	"io"
+)
+
+// A stream represents a single two-way channel
+// within a session.
+type Stream struct {
+	Sid frame.Sid
+	Session *Session
+}
+
+func (stream *Stream) SendFrame(typ frame.FrameType, flags uint8, data []uint8) error {
+	fh := new(frame.FrameHeader)
+	fh.Sid = stream.Sid
+	fh.Flags = flags
+	fh.Type = typ
+	fh.Length = uint32(len(data))
+
+	if err := fh.Marshal(stream.Session.Outgoing); err != nil {
+		return err
+	}
+	if data == nil || len(data) == 0 {
+		return nil
+	}
+	_, err := io.Copy(stream.Session.Outgoing, bytes.NewReader(data))
+	return err
+}
+
+func (stream *Stream) ExpectFrameType(typ frame.FrameType) (*frame.FrameHeader, error) {
+	fh := new(frame.FrameHeader)
+	err := fh.Unmarshal(stream.Session.Incoming)
+	if err != nil {
+		return nil, err
+	}
+	if fh.Type != typ {
+		return nil, fmt.Errorf("expected %s, got %s", typ, fh.Type)
+	}
+	if fh.Sid != stream.Sid {
+		return nil, fmt.Errorf("expected stream %d, got %d", stream.Sid, fh.Sid)
+	}
+	return fh, nil
+}
+


### PR DESCRIPTION
Add encoding methods for some of the go objects that have decode methods.

Additionally, rig a "404" response with some random headers to see them get encoded and pop back up on the client side.